### PR TITLE
Add GazeColumn Filament component

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ $panel->plugins([
 3. Publish the assets with `php artisan filament:assets`.
 4. Import the package inside your Filament Resource with `use DiscoveryDesign\FilamentGaze\Forms\Components\GazeBanner`.
 5. Add the `GazeBanner` form component to your form with `GazeBanner::make()`.
-6. If required, publish the translation files with `php artisan vendor:publish --tag=filament-gaze-translations`.
+6. (Optionally) add the `GazeColumn` table column to your table with `GazeColumn::make()`.
+7. If required, publish the translation files with `php artisan vendor:publish --tag=filament-gaze-translations`.
 
 ## Examples
 
 ### Basic Example
+
 ```php
 <?php
 
@@ -60,6 +62,16 @@ class OrderResource extends Resource
             ->schema([
                 GazeBanner::make('gaze_banner'), // Must be unique to each banner. If you have 2 or more banners in 1 schema, you must pass unique identifiers to them.
                     
+                // ...
+            ]);
+    }
+    
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                GazeColumn::make(), 
+                
                 // ...
             ]);
     }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,28 @@ GazeBanner::make('gaze_banner')
     ->hideOnCreate(),
 ```
 
+## Table column and helper
+
+Use the helper and table column for list views:
+
+```php
+use DiscoveryDesign\FilamentGaze\Gaze;
+use DiscoveryDesign\FilamentGaze\Tables\Columns\GazeColumn;
+
+GazeColumn::make();
+
+if (Gaze::isOpened($record)) {
+    // somebody is currently viewing this record
+}
+```
+
+Available helper methods:
+
+- `Gaze::isOpened($record, $excludeCurrentUser = true)`
+- `Gaze::getViewerCount($record, $excludeCurrentUser = false)`
+- `Gaze::isLockedByOther($record)`
+- `Gaze::getViewers($record, $excludeCurrentUser = true)`
+- `Gaze::getIdentifier($record)`
 
 ## Docs
 
@@ -156,4 +178,3 @@ To [customize the icons](https://filamentphp.com/docs/3.x/support/icons#replacin
 ## Author
 
 🚀 [Discovery Design](https://discoverydesign.co.uk)
-

--- a/resources/lang/en/gaze.php
+++ b/resources/lang/en/gaze.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'tooltip' => 'Number of people currently viewing this record.',
     'banner_text' => 'This page is currently being viewed by :viewers.',
     'banner_text_other' => 'This page is currently being viewed by :viewers and :count other.',
     'banner_text_others' => 'This page is currently being viewed by :viewers and :count others.',

--- a/src/Gaze.php
+++ b/src/Gaze.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DiscoveryDesign\FilamentGaze;
+
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+
+final class Gaze
+{
+    public static function isOpened(null|Model $record, bool $excludeCurrentUser = true): bool
+    {
+        $viewers = self::getViewers($record, $excludeCurrentUser);
+
+        return count($viewers) > 0;
+    }
+
+    public static function getViewers(null|Model $record, bool $excludeCurrentUser = true): array
+    {
+        if (!$record) {
+            return [];
+        }
+
+        $currentUserId = self::getCurrentUserId();
+        $viewers = [];
+
+        foreach (self::getRawViewers($record) as $viewer) {
+            if ($excludeCurrentUser && isset($viewer['id']) && $viewer['id'] === $currentUserId) {
+                continue;
+            }
+
+            if (isset($viewer['expires']) && now()->lt(Carbon::parse($viewer['expires']))) {
+                $viewers[] = $viewer;
+            }
+        }
+
+        return $viewers;
+    }
+
+    private static function getCurrentUserId(): mixed
+    {
+        $authGuard = Filament::getCurrentPanel()?->getAuthGuard() ?? config('filament.default_auth_guard', 'web');
+
+        return auth()->guard($authGuard)?->id();
+    }
+
+    private static function getRawViewers(Model $record): array
+    {
+        $identifier = self::getIdentifier($record);
+
+        return Cache::get('filament-gaze-' . $identifier, []);
+    }
+
+    public static function getIdentifier(Model $record): string
+    {
+        return get_class($record) . '-' . $record->getKey();
+    }
+
+    public static function getViewerCount(null|Model $record, bool $excludeCurrentUser = false): int
+    {
+        $viewers = self::getViewers($record, $excludeCurrentUser);
+
+        return count($viewers);
+    }
+
+    public static function isLockedByOther(null|Model $record): bool
+    {
+        if (!$record) {
+            return false;
+        }
+
+        $currentUserId = self::getCurrentUserId();
+
+        foreach (self::getRawViewers($record) as $viewer) {
+            if (
+                ($viewer['has_control'] ?? false) === true
+                && isset($viewer['id']) && $viewer['id'] !== $currentUserId
+                && isset($viewer['expires']) && now()->lt(Carbon::parse($viewer['expires']))
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Tables/Columns/GazeColumn.php
+++ b/src/Tables/Columns/GazeColumn.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DiscoveryDesign\FilamentGaze\Tables\Columns;
+
+use DiscoveryDesign\FilamentGaze\Gaze;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+
+final class GazeColumn extends TextColumn
+{
+    protected bool $excludeCurrentUser = false;
+
+    public static function make(string|null $name = null): static
+    {
+        return parent::make($name ?? 'gaze_status');
+    }
+
+    public function excludeCurrentUser(bool $exclude = true): static
+    {
+        $this->excludeCurrentUser = $exclude;
+
+        return $this;
+    }
+
+    public function getState(): mixed
+    {
+        return $this->getIsOpened($this->getRecord());
+    }
+
+    public function getIsOpened($record): bool
+    {
+        return Gaze::isOpened($record, $this->excludeCurrentUser);
+    }
+
+    public function getId(): string
+    {
+        return 'filament-gaze-gaze-column';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this
+            ->label('Viewing')
+            ->tooltip(__('filament-gaze::gaze.tooltip'))
+            ->icon(Heroicon::OutlinedUser)
+            ->iconColor(fn ($record) => $this->getViewerCount($record) > 0 ? 'danger' : 'success')
+            ->formatStateUsing(fn ($record) => $this->getViewerCount($record))
+            ->toggleable()
+            ->sortable(false)
+            ->searchable(false);
+    }
+
+    public function getViewerCount($record): int
+    {
+        return Gaze::getViewerCount($record, $this->excludeCurrentUser);
+    }
+}


### PR DESCRIPTION
This PR adds a GazeColumn to be used in filament tables, so that the table view already indicates whether a record is viewed/locked by somebody.

This is just a visual indicator, no special functionality.

Please also refer to the README.md changes.

If you need any more information or changes, please let me know.

